### PR TITLE
Fix testing in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ git clone https://github.com/cs3org/reva
 cd reva
 make deps
 make
-cd examples/ocmd/ && mkdir -p /tmp/reva && && mkdir -p /var/tmp/reva 
+mkdir -p /var/tmp/reva
+cd examples/ocmd/
+../../cmd/revad/revad -c ocmd-server-1.toml
 ```
 
 #### Run test


### PR DESCRIPTION
This PR fixes README's section about testing.

Currently, that section is incorrect:

* The command has incorrect syntax (`&& &&`)
* No command running `revad`
* Not needed directory `/tmp/reva` (to my experience)
* (improvement) No purpose in combining the unrelated `cd` and `mkdir` in one line