### PR TITLE
Simple locking mechanism #11

### DIFF
--- a/cs3api4lab/api/cs3_file_api.py
+++ b/cs3api4lab/api/cs3_file_api.py
@@ -21,6 +21,8 @@ from cs3api4lab.auth import check_auth_interceptor
 from cs3api4lab.auth.authenticator import Auth
 from cs3api4lab.auth.channel_connector import ChannelConnector
 from cs3api4lab.config.config_manager import Cs3ConfigManager
+from cs3api4lab.api.cs3_locks_api import LocksApi
+from cs3api4lab.api.storage_api import StorageApi
 
 
 class Cs3FileApi:
@@ -37,6 +39,8 @@ class Cs3FileApi:
         auth_interceptor = check_auth_interceptor.CheckAuthInterceptor(log, self.auth)
         intercept_channel = grpc.intercept_channel(channel, auth_interceptor)
         self.cs3_api = cs3gw_grpc.GatewayAPIStub(intercept_channel)
+        self.locks_api = LocksApi(self.log)
+        self.storage_api = StorageApi(self.log)
         return
 
     def stat(self, file_id, endpoint=None):
@@ -71,116 +75,11 @@ class Cs3FileApi:
         raise FileNotFoundError(stat_info.status.message + ", file " + file_id)
 
     def read_file(self, file_path, endpoint=None):
-        """
-        Read a file using the given userid as access token.
-        """
-        time_start = time.time()
-        #
-        # Prepare endpoint
-        #
-        reference = file_utils.get_reference(file_path, endpoint)
-        req = cs3sp.InitiateFileDownloadRequest(ref=reference)
-        init_file_download = self.cs3_api.InitiateFileDownload(request=req, metadata=[
-            ('x-access-token', self.auth.authenticate())])
-
-        if init_file_download.status.code == cs3code.CODE_NOT_FOUND:
-            self.log.info('msg="File not found on read" filepath="%s"' % file_path)
-            raise IOError('No such file or directory')
-
-        elif init_file_download.status.code != cs3code.CODE_OK:
-            self.log.debug('msg="Failed to initiateFileDownload on read" filepath="%s" reason="%s"' % file_path,
-                           init_file_download.status.message)
-            raise IOError(init_file_download.status.message)
-
-        self.log.debug(
-            'msg="readfile: InitiateFileDownloadRes returned" protocols="%s"' % init_file_download.protocols)
-
-        #
-        # Download
-        #
-        file_get = None
-        try:
-            protocol = [p for p in init_file_download.protocols if p.protocol == "simple"][0]
-            headers = {
-                'x-access-token': self.auth.authenticate(),
-                'X-Reva-Transfer': protocol.token    # needed if the downloads pass through the data gateway in reva
-            }
-            file_get = requests.get(url=protocol.download_endpoint, headers=headers)
-        except requests.exceptions.RequestException as e:
-            self.log.error('msg="Exception when downloading file from Reva" reason="%s"' % e)
-            raise IOError(e)
-
-        time_end = time.time()
-        data = file_get.content
-
-        if file_get.status_code != http.HTTPStatus.OK:
-            self.log.error('msg="Error downloading file from Reva" code="%d" reason="%s"' % (
-                file_get.status_code, file_get.reason))
-            raise IOError(file_get.reason)
-        else:
-            self.log.info('msg="File open for read" filepath="%s" elapsedTimems="%.1f"' % (
-                file_path, (time_end - time_start) * 1000))
-            for i in range(0, len(data), int(self.config['chunk_size'])):
-                yield data[i:i + int(self.config['chunk_size'])]
+        self.locks_api.on_open_hook(file_path, endpoint)
+        return self.storage_api.read_file(file_path, endpoint)
 
     def write_file(self, file_path, content, endpoint=None):
-        """
-        Write a file using the given userid as access token. The entire content is written
-        and any pre-existing file is deleted (or moved to the previous version if supported).
-        """
-        #
-        # Prepare endpoint
-        #
-        time_start = time.time()
-        reference = file_utils.get_reference(file_path, endpoint)
-
-        if isinstance(content, str):
-            content_size = str(len(content))
-        else:
-            content_size = str(len(content.decode('utf-8')))
-
-        meta_data = types.Opaque(
-            map={"Upload-Length": types.OpaqueEntry(decoder="plain", value=str.encode(content_size))})
-        req = cs3sp.InitiateFileUploadRequest(ref=reference, opaque=meta_data)
-        init_file_upload_res = self.cs3_api.InitiateFileUpload(request=req, metadata=[
-            ('x-access-token', self.auth.authenticate())])
-
-        if init_file_upload_res.status.code != cs3code.CODE_OK:
-            self.log.debug('msg="Failed to initiateFileUpload on write" file_path="%s" reason="%s"' % \
-                           (file_path, init_file_upload_res.status.message))
-            raise IOError(init_file_upload_res.status.message)
-
-        self.log.debug(
-            'msg="writefile: InitiateFileUploadRes returned" protocols="%s"' % init_file_upload_res.protocols)
-
-        #
-        # Upload
-        #
-        try:
-            protocol = [p for p in init_file_upload_res.protocols if p.protocol == "simple"][0]
-            headers = {
-                'Tus-Resumable': '1.0.0',
-                'File-Path': file_path,
-                'File-Size': content_size,
-                'x-access-token': self.auth.authenticate(),
-                'X-Reva-Transfer': protocol.token
-            }
-            put_res = requests.put(url=protocol.upload_endpoint, data=content, headers=headers)
-
-        except requests.exceptions.RequestException as e:
-            self.log.error('msg="Exception when uploading file to Reva" reason="%s"' % e)
-            raise IOError(e)
-
-        time_end = time.time()
-
-        if put_res.status_code != http.HTTPStatus.OK:
-            self.log.error(
-                'msg="Error uploading file to Reva" code="%d" reason="%s"' % (put_res.status_code, put_res.reason))
-            raise IOError(put_res.reason)
-
-        self.log.info(
-            'msg="File open for write" filepath="%s" elapsedTimems="%.1f"' % (
-                file_path, (time_end - time_start) * 1000))
+        self.storage_api.write_file(file_path, content, endpoint)
 
     def remove(self, file_path, endpoint=None):
         """
@@ -205,6 +104,7 @@ class Cs3FileApi:
         """
         Read a directory.
         """
+        self.locks_api.check_locks()
         tstart = time.time()
         reference = file_utils.get_reference(path, endpoint)
         req = cs3sp.ListContainerRequest(ref=reference, arbitrary_metadata_keys="*")

--- a/cs3api4lab/api/cs3_file_api.py
+++ b/cs3api4lab/api/cs3_file_api.py
@@ -104,7 +104,6 @@ class Cs3FileApi:
         """
         Read a directory.
         """
-        self.locks_api.check_locks()
         tstart = time.time()
         reference = file_utils.get_reference(path, endpoint)
         req = cs3sp.ListContainerRequest(ref=reference, arbitrary_metadata_keys="*")

--- a/cs3api4lab/api/cs3_locks_api.py
+++ b/cs3api4lab/api/cs3_locks_api.py
@@ -1,0 +1,264 @@
+import cs3.gateway.v1beta1.gateway_api_pb2 as cs3gw
+import cs3.gateway.v1beta1.gateway_api_pb2_grpc as cs3gw_grpc
+import cs3.rpc.v1beta1.code_pb2 as cs3code
+import cs3.storage.provider.v1beta1.provider_api_pb2 as cs3sp
+import cs3.storage.provider.v1beta1.resources_pb2 as cs3spr
+import grpc
+from cs3api4lab.api.file_utils import FileUtils as file_utils
+from cs3api4lab.auth import check_auth_interceptor
+from cs3api4lab.auth.authenticator import Auth
+import json
+import time
+from cs3api4lab.api.cs3_user_api import Cs3UserApi
+from cs3api4lab.auth.channel_connector import ChannelConnector
+from cs3api4lab.config.config_manager import Cs3ConfigManager
+from cs3api4lab.api.storage_api import StorageApi
+
+
+class LocksApi:
+    lock_validity_s = 60
+    locks_file_id = '/.locks'
+
+    def __init__(self, log, config=None):
+        self.log = log
+        if config:
+            self.config = config
+        else:
+            self.config = Cs3ConfigManager().get_config()
+        self.auth = Auth.get_authenticator(config=self.config, log=self.log)
+        channel = ChannelConnector().get_channel()
+        auth_interceptor = check_auth_interceptor.CheckAuthInterceptor(log, self.auth)
+        intercept_channel = grpc.intercept_channel(channel, auth_interceptor)
+        self.cs3_api = cs3gw_grpc.GatewayAPIStub(intercept_channel)
+        self.user_api = Cs3UserApi(log)
+        self.storage_api = StorageApi(self.log)
+        return
+
+    def get_copies_info(self, file_id, endpoint):
+        ref = self.get_unified_file_ref(file_id, endpoint)
+        stat = self.stat(ref)
+        copies_info = []
+        for lock in stat.info.arbitrary_metadata.metadata:
+            if lock.startswith('copy-'):
+                if stat.info.arbitrary_metadata.metadata[lock] != '':
+                    copies_info.append(json.loads(stat.info.arbitrary_metadata.metadata[lock]))
+        return copies_info
+
+    # determine who has the oldest and still valid lock
+    def get_merger(self, file_id, endpoint):
+        copies_info = list(filter(lambda c: self._is_copy_valid(c), self.get_copies_info(file_id, endpoint)))
+        if not copies_info:
+            return None
+        else:
+            t = time.time()
+            merger = None
+            for m in copies_info:
+                if m['created'] < t:
+                    t = m['created']
+                    merger = m
+        return merger
+
+    # add lock on file opening
+    def on_open_hook(self, file_path, endpoint):
+        self.log.info('Opening ' + endpoint + file_path)
+        if self._get_lock_name() in file_path:
+            # assume this is a copy
+            self.update_lock(file_path, endpoint)
+        else:
+            # check if it is a shared file
+            # todo check if viewer
+            if self.is_shared_file(file_path, endpoint):
+                ref = self.get_unified_file_ref(file_path, endpoint)
+                copy_path = self._get_copy_path(ref)
+                copy_stat = self.stat(ref=cs3spr.Reference(path=copy_path))
+                if copy_stat.status.code == cs3code.CODE_NOT_FOUND:
+                    self.create_working_copy(ref)
+                elif copy_stat.status.code == cs3code.CODE_OK:
+                    self.update_lock(copy_stat.info.id.opaque_id, copy_stat.info.id.storage_id)
+
+    # clear lock on closing file
+    def on_close_hook(self, file_id, endpoint):
+        user = self._get_current_user()
+        if 'copy-' + user.username in file_id:
+            self.delete_lock(file_id, endpoint)
+
+    # remove info about users lock on the original file
+    def delete_lock(self, file_id, endpoint):
+        self.log.info('Deleting lock for: ' + endpoint + file_id)
+        original_ref = self._get_original_ref(file_id, endpoint)
+        lock_name = self._get_lock_name()
+        empty_lock = {lock_name: ''}
+        self.set_metadata(original_ref, empty_lock)
+        return
+
+    # copy the shared file content into new file and set lock entry on the original file,
+    # add path entry to local locks file
+    def create_working_copy(self, original_ref):
+        self.log.info('Creating woring copy for ' + original_ref.path)
+        copy_info = self.copy_file(original_ref)
+        copy_file_ref = self.get_unified_file_ref(copy_info.info.id.opaque_id,
+                                                  copy_info.info.id.storage_id)
+        original_ref = self.get_unified_file_ref(original_ref.path, self.config['endpoint'])
+        original_stat = self.stat(original_ref)
+        self.set_metadata(copy_file_ref, {"original": json.dumps({
+            "storage_id": original_stat.info.id.storage_id,
+            "opaque_id": original_stat.info.id.opaque_id
+        })})
+        self.set_metadata(original_ref, self._get_lock_entry(copy_info))
+        self.add_to_locks_file(original_ref)
+
+    def copy_file(self, original_ref):
+        content = ''
+        for chunk in self.storage_api.read_file(original_ref.path, self.config['endpoint']):
+            content += chunk.decode('utf-8')
+        path = self._get_copy_path(original_ref)
+        stat = self.stat(ref=cs3spr.Reference(path=path))
+        if stat.status.code == cs3code.CODE_OK:
+            return stat
+        else:
+            self.storage_api.write_file(path, content, self.config['endpoint'])
+            stat = self.stat(ref=cs3spr.Reference(path=path))
+        return stat
+
+    # delete invalid locks on shared files
+    def check_locks(self):
+        path = self.config['home_dir'] + self.locks_file_id
+        stat = self.stat(ref=cs3spr.Reference(path=path))
+        if stat.status.code == cs3code.CODE_OK:
+            shared_files = self.get_locks_file_content()
+            for file_path in shared_files:
+                ref = cs3spr.Reference(path=file_path)
+                stat = self.stat(ref=ref)
+                for lock in stat.info.arbitrary_metadata.metadata:
+                    if lock.startswith('copy-'):
+                        if not self._is_valid(stat.info.arbitrary_metadata.metadata, lock):
+                            if stat.info.arbitrary_metadata.metadata[lock]:
+                                self.log.info('Deleting unused lock: ' + lock + ' for file: ' + file_path)
+                                self.set_metadata(ref, {lock: ''})
+
+    def add_lock(self, file_id, endpoint):
+        copy_stat = self.stat(ref=cs3spr.Reference(id=cs3spr.ResourceId(storage_id=file_id,
+                                                                        opaque_id=endpoint)))
+        original_ref = self._get_original_ref(file_id, endpoint)
+        self.set_metadata(original_ref, self._get_lock_entry(copy_stat))
+        return
+
+    # updates lock on the original file using file copy path
+    def update_lock(self, file_id, endpoint):
+        self.log.info('Updating lock for ' + endpoint + file_id)
+        original_ref = self._get_original_ref(file_id, endpoint)
+        original_stat = self.stat(ref=original_ref)
+        copy_stat = self.stat(ref=cs3spr.Reference(id=cs3spr.ResourceId(storage_id=file_id,
+                                                                        opaque_id=endpoint)))
+        lock_name = self._get_lock_name()
+        if not original_stat.info.arbitrary_metadata.metadata[lock_name]:
+            self.set_metadata(original_ref, self._get_lock_entry(copy_stat))
+        else:
+            lock_content = json.loads(original_stat.info.arbitrary_metadata.metadata[lock_name])
+            lock_content['updated'] = time.time()
+            self.set_metadata(original_ref, {lock_name: json.dumps(lock_content)})
+
+    def add_to_locks_file(self, original_file_ref):
+        path = self.config['home_dir'] + self.locks_file_id
+        stat = self.stat(ref=cs3spr.Reference(path=path))
+        if stat.status.code != cs3code.CODE_OK:
+            self.storage_api.write_file(path, json.dumps([original_file_ref.path]), self.config['endpoint'])
+        else:
+            locks = self.get_locks_file_content()
+            if original_file_ref.path not in locks:
+                locks.append(original_file_ref.path)
+                self.storage_api.write_file(path, json.dumps(locks), self.config['endpoint'])
+
+    def _get_original_ref(self, file_id, endpoint):
+        copy_ref = self.get_unified_file_ref(file_id, endpoint)
+        copy_stat = self.stat(ref=copy_ref)
+        if not copy_stat.info.arbitrary_metadata.metadata['original']:
+            raise Exception("File " + endpoint + file_id + " has no original set")
+        original_id = json.loads(copy_stat.info.arbitrary_metadata.metadata['original'])
+        original_ref = self.get_unified_file_ref(original_id['opaque_id'], original_id['storage_id'])
+        return original_ref
+
+    def _get_copy_path(self, original_ref):
+        file_path = original_ref.path.split('/')[-1]
+        file_name = file_path.split('.')
+        return self.config['home_dir'] + '/' + self._get_lock_name() + file_name[0] + '.' + file_name[-1]
+
+    def set_metadata(self, ref, entry):
+        set_metadata_response = self.cs3_api.SetArbitraryMetadata(
+            request=cs3sp.SetArbitraryMetadataRequest(
+                ref=ref,
+                arbitrary_metadata=cs3spr.ArbitraryMetadata(metadata=entry)),
+            metadata=self._get_token())
+        if set_metadata_response.status.code != cs3code.CODE_OK:
+            raise Exception('Unable to set metadata for: ' + ref.path + ' ' + set_metadata_response.status)
+
+    def get_unified_file_ref(self, file_id, endpoint):
+        ref = file_utils.get_reference(file_id, endpoint)
+        stat = self.stat(ref)
+        if stat.status.code == cs3code.CODE_NOT_FOUND:
+            return None
+        else:
+            stat_unified = self.stat(ref=cs3spr.Reference(
+                id=cs3spr.ResourceId(storage_id=stat.info.id.storage_id,
+                                     opaque_id=stat.info.id.opaque_id)))
+            return cs3spr.Reference(path=stat_unified.info.path)
+
+    def _get_current_user(self):
+        return self.cs3_api.WhoAmI(request=cs3gw.WhoAmIRequest(token=self.auth.authenticate()),
+                                   metadata=self._get_token()).user
+
+    def stat(self, ref):
+        return self.cs3_api.Stat(request=cs3sp.StatRequest(ref=ref),
+                                 metadata=self._get_token())
+
+    def _get_lock_entry(self, copy_info):
+        user = self._get_current_user()
+        return {self._get_lock_name(): json.dumps({
+            "username": user.username,
+            "idp": user.id.idp,
+            "opaque_id": user.id.opaque_id,
+            "copy_info": {
+                "storage_id": copy_info.info.id.storage_id,
+                "opaque_id": copy_info.info.id.opaque_id
+            },
+            "updated": time.time(),
+            "created": time.time()
+        })}
+
+    def _get_lock_name(self):
+        user = self._get_current_user()
+        return 'copy-' + user.username + '_' + user.id.idp + '_' + user.id.opaque_id + '_'
+
+    def is_shared_file(self, file_path, endpoint):
+        import cs3api4lab.api.cs3_share_api as s
+        share_api = s.Cs3ShareApi(self.log, self.config, self.auth)
+        stat = self.stat(self.get_unified_file_ref(file_path, endpoint))
+        shares = share_api.list().shares
+        for share in shares:
+            if share.resource_id.storage_id == stat.info.id.storage_id and share.resource_id.opaque_id == stat.info.id.opaque_id.replace('fileid-%2F', 'fileid-'):
+                return True
+        shares_received = share_api.get_received_shares().shares
+        for share in shares_received:
+            if share.share.resource_id.storage_id == stat.info.id.storage_id and share.share.resource_id.opaque_id == stat.info.id.opaque_id.replace('fileid-%2F', 'fileid-'):
+                return True
+        return False
+
+    def _create_locks_file(self):
+        self.storage_api.write_file(self.config['home_dir'] + self.locks_file_id, '', self.config['endpoint'])
+
+    def get_locks_file_content(self):
+        path = self.config['home_dir'] + self.locks_file_id
+        content = ''
+        for chunk in self.storage_api.read_file(path, self.config['endpoint']):
+            content += chunk.decode('utf-8')
+        return json.loads(content)
+
+    def _is_valid(self, metadata, lock):
+        lock_content = metadata[lock]
+        return bool(lock_content and (time.time() - json.loads(lock_content)['updated'] < self.lock_validity_s))
+
+    def _is_copy_valid(self, copy):
+        return time.time() - copy['updated'] < self.lock_validity_s
+
+    def _get_token(self):
+        return [('x-access-token', self.auth.authenticate())]

--- a/cs3api4lab/api/storage_api.py
+++ b/cs3api4lab/api/storage_api.py
@@ -1,0 +1,137 @@
+import http
+import time
+
+import cs3.gateway.v1beta1.gateway_api_pb2_grpc as cs3gw_grpc
+import cs3.rpc.code_pb2 as cs3code
+import cs3.storage.provider.v1beta1.provider_api_pb2 as cs3sp
+import cs3.types.v1beta1.types_pb2 as types
+import grpc
+import requests
+
+from cs3api4lab.api.file_utils import FileUtils as file_utils
+from cs3api4lab.auth import check_auth_interceptor
+from cs3api4lab.auth.authenticator import Auth
+from cs3api4lab.auth.channel_connector import ChannelConnector
+from cs3api4lab.config.config_manager import Cs3ConfigManager
+
+
+class StorageApi:
+
+    def __init__(self, log):
+        self.log = log
+        self.config = Cs3ConfigManager().get_config()
+        self.auth = Auth.get_authenticator(config=self.config, log=self.log)
+        channel = ChannelConnector().get_channel()
+        auth_interceptor = check_auth_interceptor.CheckAuthInterceptor(log, self.auth)
+        intercept_channel = grpc.intercept_channel(channel, auth_interceptor)
+        self.cs3_api = cs3gw_grpc.GatewayAPIStub(intercept_channel)
+        # self.locks_api = LocksApi(self.log)
+
+    def read_file(self, file_path, endpoint=None):
+        time_start = time.time()
+        #
+        # Prepare endpoint
+        #
+        reference = file_utils.get_reference(file_path, endpoint)
+        req = cs3sp.InitiateFileDownloadRequest(ref=reference)
+        init_file_download = self.cs3_api.InitiateFileDownload(request=req, metadata=[
+            ('x-access-token', self.auth.authenticate())])
+
+        if init_file_download.status.code == cs3code.CODE_NOT_FOUND:
+            self.log.info('msg="File not found on read" filepath="%s"' % file_path)
+            raise IOError('No such file or directory')
+
+        elif init_file_download.status.code != cs3code.CODE_OK:
+            self.log.debug('msg="Failed to initiateFileDownload on read" filepath="%s" reason="%s"' % file_path,
+                           init_file_download.status.message)
+            raise IOError(init_file_download.status.message)
+
+        self.log.debug(
+            'msg="readfile: InitiateFileDownloadRes returned" protocols="%s"' % init_file_download.protocols)
+
+        #
+        # Download
+        #
+        file_get = None
+        try:
+            protocol = [p for p in init_file_download.protocols if p.protocol == "simple"][0]
+            headers = {
+                'x-access-token': self.auth.authenticate(),
+                'X-Reva-Transfer': protocol.token  # needed if the downloads pass through the data gateway in reva
+            }
+            file_get = requests.get(url=protocol.download_endpoint, headers=headers)
+        except requests.exceptions.RequestException as e:
+            self.log.error('msg="Exception when downloading file from Reva" reason="%s"' % e)
+            raise IOError(e)
+
+        time_end = time.time()
+        data = file_get.content
+
+        if file_get.status_code != http.HTTPStatus.OK:
+            self.log.error('msg="Error downloading file from Reva" code="%d" reason="%s"' % (
+                file_get.status_code, file_get.reason))
+            raise IOError(file_get.reason)
+        else:
+            self.log.info('msg="File open for read" filepath="%s" elapsedTimems="%.1f"' % (
+                file_path, (time_end - time_start) * 1000))
+            for i in range(0, len(data), int(self.config['chunk_size'])):
+                yield data[i:i + int(self.config['chunk_size'])]
+
+    def write_file(self, file_path, content, endpoint=None):
+        """
+        Write a file using the given userid as access token. The entire content is written
+        and any pre-existing file is deleted (or moved to the previous version if supported).
+        """
+        #
+        # Prepare endpoint
+        #
+        time_start = time.time()
+        reference = file_utils.get_reference(file_path, endpoint)
+
+        if isinstance(content, str):
+            content_size = str(len(content))
+        else:
+            content_size = str(len(content.decode('utf-8')))
+
+        meta_data = types.Opaque(
+            map={"Upload-Length": types.OpaqueEntry(decoder="plain", value=str.encode(content_size))})
+        req = cs3sp.InitiateFileUploadRequest(ref=reference, opaque=meta_data)
+        init_file_upload_res = self.cs3_api.InitiateFileUpload(request=req, metadata=[
+            ('x-access-token', self.auth.authenticate())])
+
+        if init_file_upload_res.status.code != cs3code.CODE_OK:
+            self.log.debug('msg="Failed to initiateFileUpload on write" file_path="%s" reason="%s"' % \
+                           (file_path, init_file_upload_res.status.message))
+            raise IOError(init_file_upload_res.status.message)
+
+        self.log.debug(
+            'msg="writefile: InitiateFileUploadRes returned" protocols="%s"' % init_file_upload_res.protocols)
+
+        #
+        # Upload
+        #
+        try:
+            protocol = [p for p in init_file_upload_res.protocols if p.protocol == "simple"][0]
+            headers = {
+                'Tus-Resumable': '1.0.0',
+                'File-Path': file_path,
+                'File-Size': content_size,
+                'x-access-token': self.auth.authenticate(),
+                'X-Reva-Transfer': protocol.token
+            }
+            put_res = requests.put(url=protocol.upload_endpoint, data=content, headers=headers)
+
+        except requests.exceptions.RequestException as e:
+            self.log.error('msg="Exception when uploading file to Reva" reason="%s"' % e)
+            raise IOError(e)
+
+        time_end = time.time()
+
+        if put_res.status_code != http.HTTPStatus.OK:
+            self.log.error(
+                'msg="Error uploading file to Reva" code="%d" reason="%s"' % (put_res.status_code, put_res.reason))
+            raise IOError(put_res.reason)
+
+        self.log.info(
+            'msg="File open for write" filepath="%s" elapsedTimems="%.1f"' % (
+                file_path, (time_end - time_start) * 1000))

--- a/cs3api4lab/tests/test_cs3_access_share.py
+++ b/cs3api4lab/tests/test_cs3_access_share.py
@@ -42,7 +42,7 @@ class ExtCs3ShareApi(Cs3ShareApi):
         self.log = log
 
     def list(self):
-        list_response = self._list()
+        list_response = self.list()
         return self._map_given_shares(list_response)
 
 

--- a/cs3api4lab/tests/test_cs3_locks.py
+++ b/cs3api4lab/tests/test_cs3_locks.py
@@ -164,8 +164,6 @@ class TestCs3FileApi(TestCase, LoggingConfigurable):
             locks_ref = cs3spr.Reference(path=self.locks_file_path)
             locks_stat = self.locks_api.stat(locks_ref)
             self.assertTrue(locks_stat.status.code == cs3code.CODE_OK)
-            locks_content = self.locks_api.get_locks_file_content()
-            self.assertTrue(self.file_path_uni in locks_content)
             copy_stat = self.locks_api.stat(self.locks_api.get_unified_file_ref(self.file_copy_path, self.endpoint))
             self.assertTrue('test_file.txt' in copy_stat.info.arbitrary_metadata.metadata['original'])
             self.assertTrue(True)
@@ -211,7 +209,6 @@ class TestCs3FileApi(TestCase, LoggingConfigurable):
             self._remove_share('einstein')
             self._remove_test_file('einstein', self.file_path)
 
-
     def test_get_merger(self):
         try:
             self._create_test_file('einstein', self.file_path)
@@ -242,18 +239,12 @@ class TestCs3FileApi(TestCase, LoggingConfigurable):
         try:
             self._create_test_file('einstein', self.file_path)
             self._create_share('einstein')
-            self.locks_api.check_locks()
 
             self.locks_api.create_working_copy(cs3spr.Reference(path=self.file_path))
             copies = self.locks_api.get_copies_info(self.file_path, self.endpoint)
             self.assertTrue(len(copies) == 1)
 
-            self.locks_api.check_locks()
-            copies = self.locks_api.get_copies_info(self.file_path, self.endpoint)
-            self.assertTrue(len(copies) == 1)
-
             time.sleep(60)
-            self.locks_api.check_locks()
             copies = self.locks_api.get_copies_info(self.file_path, self.endpoint)
             self.assertTrue(len(copies) == 0)
         finally:
@@ -319,15 +310,11 @@ class TestCs3FileApi(TestCase, LoggingConfigurable):
             self.assertTrue(stat.status.code == cs3code.CODE_NOT_FOUND)
 
             self.locks_api.on_open_hook(self.file_path, self.endpoint)
-            locks_content = self.locks_api.get_locks_file_content()
-            self.assertTrue(self.file_path_uni in locks_content)
             stat = self.locks_api.stat(copy_ref)
             self.assertTrue(stat.status.code == cs3code.CODE_OK)
             merger = self.locks_api.get_merger(self.file_path, self.endpoint)
 
             self.locks_api_ext.on_open_hook(self.file_path_uni, self.endpoint)
-            locks_content_marie = self.locks_api_ext.get_locks_file_content()
-            self.assertTrue(self.file_path_uni in locks_content_marie)
             copy_ref_marie = cs3spr.Reference(path=self.locks_api_ext._get_copy_path(ref))
             stat_marie = self.locks_api_ext.stat(copy_ref_marie)
             self.assertTrue(stat_marie.status.code == cs3code.CODE_OK)

--- a/cs3api4lab/tests/test_cs3_locks.py
+++ b/cs3api4lab/tests/test_cs3_locks.py
@@ -1,0 +1,393 @@
+import time
+from unittest import TestCase
+from cs3api4lab.api.cs3_locks_api import LocksApi
+from traitlets.config import LoggingConfigurable
+import cs3.storage.provider.v1beta1.resources_pb2 as cs3spr
+import cs3.rpc.v1beta1.code_pb2 as cs3code
+from cs3api4lab.api.cs3_user_api import Cs3UserApi
+from cs3api4lab import CS3APIsManager
+from cs3api4lab.api.cs3_file_api import Cs3FileApi
+from cs3api4lab.api.cs3_share_api import Cs3ShareApi
+from cs3api4lab.auth import RevaPassword
+from cs3api4lab.auth.channel_connector import ChannelConnector
+from cs3api4lab.config.config_manager import Cs3ConfigManager
+import cs3.gateway.v1beta1.gateway_api_pb2_grpc as cs3gw_grpc
+import cs3.identity.user.v1beta1.user_api_pb2_grpc as user_api_grpc
+from cs3api4lab.api.storage_api import StorageApi
+from cs3api4lab.auth import check_auth_interceptor
+import grpc
+
+
+class ExtAuthenticator(RevaPassword):
+    def __init__(self, config, log):
+        super().__init__(config, log)
+        self.config = config
+        self.log = log
+        channel = ChannelConnector().get_channel()
+        self.cs3_api = cs3gw_grpc.GatewayAPIStub(channel)
+
+
+class ExtCs3File(Cs3FileApi):
+    def __init__(self, log, config) -> None:
+        self.log = log
+        self.config = config
+        self.auth = ExtAuthenticator(config, log)
+        channel = ChannelConnector().get_channel()
+        self.cs3_api = cs3gw_grpc.GatewayAPIStub(channel)
+        self.storage_api = ExtStorageApi(log, config)
+
+
+class ExtCs3ShareApi(Cs3ShareApi):
+    def __init__(self, log, config) -> None:
+        self.config = config
+        self.auth = ExtAuthenticator(config, log)
+        self.file_api = ExtCs3File(log, config)
+        self.cs3_api = cs3gw_grpc.GatewayAPIStub(ChannelConnector().get_channel())
+        self.log = log
+
+    def list(self):
+        list_response = self.list()
+        return self._map_given_shares(list_response)
+
+
+class ExtUserApi(Cs3UserApi):
+    def __init__(self, log, config) -> None:
+        self.api = user_api_grpc.UserAPIStub(ChannelConnector().get_channel())
+        self.config = config
+        self.auth = ExtAuthenticator(log, config)
+
+
+class ExtStorageApi(StorageApi):
+    def __init__(self, log, config) -> None:
+        self.log = log
+        self.config = config
+        self.auth = ExtAuthenticator(config, log)
+        channel = ChannelConnector().get_channel()
+        auth_interceptor = check_auth_interceptor.CheckAuthInterceptor(log, self.auth)
+        intercept_channel = grpc.intercept_channel(channel, auth_interceptor)
+        self.cs3_api = cs3gw_grpc.GatewayAPIStub(intercept_channel)
+
+
+class ExtCs3LocksApi(LocksApi):
+    def __init__(self, log, config) -> None:
+        self.log = log
+        self.config = config
+        self.auth = ExtAuthenticator(config, log)
+        self.cs3_api = cs3gw_grpc.GatewayAPIStub(ChannelConnector().get_channel())
+        self.user_api = ExtUserApi(log, config)
+        self.file_api = ExtCs3File(log, config)
+        self.storage_api = ExtStorageApi(log, config)
+
+
+class ExtCS3APIsManager(CS3APIsManager):
+    def __init__(self, parent, log, config):
+        self.cs3_config = config
+        self.log = log
+        self.file_api = ExtCs3File(log, config)
+
+
+class TestCs3FileApi(TestCase, LoggingConfigurable):
+    config = None
+
+    file_copy_path = '/home/copy-einstein_cernbox.cern.ch_4c510ada-c86b-4815-8820-42cdf82c3d51_test_file.txt'
+    file_copy_path2 = '/home/copy-marie_cesnet.cz_f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c_test_file.txt'
+    file_path = '/home/test_file.txt'
+    file_path_uni = '/reva/einstein/test_file.txt'
+    file_path2 = '/home/test_file2.txt'
+    locks_file_path = '/home/.locks'
+    lock_name = 'copy-einstein_cernbox.cern.ch_4c510ada-c86b-4815-8820-42cdf82c3d51_'
+    file_copy_path_uni = '/reva/einstein/copy-einstein_cernbox.cern.ch_4c510ada-c86b-4815-8820-42cdf82c3d51_test_einstein_share_file.txt'
+
+    user_opaque_id_1 = 'f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c'
+    user_idp_1 = 'cesnet.cz'
+
+    user_opaque_id_2 = '4c510ada-c86b-4815-8820-42cdf82c3d51'
+    user_idp_2 = 'cernbox.cern.ch'
+
+    editor_role = 'editor'
+    endpoint = "/"
+    content = f"Lorem ipsum..."
+
+    first_client_id = "einstein"
+    first_client_secret = "relativity"
+
+    second_client_id = "marie"
+    second_client_secret = "radioactivity"
+
+    def setUp(self):
+        config = Cs3ConfigManager.get_config()
+        self.client_id = config['client_id']
+        self.endpoint = config['endpoint']
+        self.storage = Cs3FileApi(self.log)
+
+        self.config = Cs3ConfigManager().get_config()
+        self.config_ext = self.config.copy()
+
+        self.locks_api = LocksApi(self.log)
+        self.locks_api_ext = ExtCs3LocksApi(self.log, self.config_ext)
+
+        self.storage_new = ExtStorageApi(self.log, self.config)
+
+        self.config["client_id"] = self.first_client_id
+        self.config["client_secret"] = self.first_client_secret
+
+        self.config_ext["client_id"] = self.second_client_id
+        self.config_ext["client_secret"] = self.second_client_secret
+
+        self.storage = ExtCs3File(self.log, self.config)
+        self.share_api = ExtCs3ShareApi(self.log, self.config)
+
+        self.storage_ext = ExtCs3File(self.log, self.config_ext)
+        self.share_api_ext = ExtCs3ShareApi(self.log, self.config_ext)
+
+        self.manager_ext = ExtCS3APIsManager(None, self.log, self.config_ext)
+
+    def test_copy_file(self):
+        try:
+            self._create_test_file('einstein', self.file_path)
+            self._create_share('einstein')
+            original_ref = cs3spr.Reference(path=self.file_path)
+            copy_stat = self.locks_api.copy_file(original_ref)
+            self.assertTrue(copy_stat.status.code == cs3code.CODE_OK)
+            self.assertTrue(self.file_copy_path in copy_stat.info.path)
+        finally:
+            self._remove_share('einstein')
+            self._remove_test_file('einstein', self.file_path)
+            self._remove_test_file('einstein', self.file_copy_path)
+
+    def test_create_working_copy(self):
+        try:
+            self._create_test_file('einstein', self.file_path)
+            self._create_share('einstein')
+            ref = cs3spr.Reference(path=self.file_path)
+            self.locks_api.create_working_copy(ref)
+            locks_ref = cs3spr.Reference(path=self.locks_file_path)
+            locks_stat = self.locks_api.stat(locks_ref)
+            self.assertTrue(locks_stat.status.code == cs3code.CODE_OK)
+            locks_content = self.locks_api.get_locks_file_content()
+            self.assertTrue(self.file_path_uni in locks_content)
+            copy_stat = self.locks_api.stat(self.locks_api.get_unified_file_ref(self.file_copy_path, self.endpoint))
+            self.assertTrue('test_file.txt' in copy_stat.info.arbitrary_metadata.metadata['original'])
+            self.assertTrue(True)
+        finally:
+            self._remove_share('einstein')
+            self._remove_test_file('einstein', self.file_path)
+            self._remove_test_file('einstein', self.file_copy_path)
+            self.storage.remove(self.locks_file_path)
+
+    def test_get_copies_info_when_one_copy(self):
+        try:
+            self._create_test_file('einstein', self.file_path)
+            self._create_share('einstein')
+            self.locks_api.create_working_copy(cs3spr.Reference(path=self.file_path))
+            copies = self.locks_api.get_copies_info(self.file_path, self.endpoint)
+            self.assertFalse(copies == [])
+        finally:
+            self._remove_share('einstein')
+            self._remove_test_file('einstein', self.file_path)
+
+    def test_get_copies_info_when_no_copies(self):
+        try:
+            self._create_test_file('einstein', self.file_path)
+            self._create_share('einstein')
+            copies = self.locks_api.get_copies_info(self.file_path, self.endpoint)
+            self.assertTrue(copies == [])
+        finally:
+            self._remove_share('einstein')
+            self._remove_test_file('einstein', self.file_path)
+
+    def test_delete_lock(self):
+        try:
+            self._create_test_file('einstein', self.file_path)
+            self._create_share('einstein')
+            ref = cs3spr.Reference(path=self.file_path)
+            self.locks_api.create_working_copy(ref)
+            self.locks_api.delete_lock(self.file_copy_path, self.endpoint)
+            fr = self.locks_api.get_unified_file_ref(self.file_path, self.endpoint)
+            stat = self.locks_api.stat(fr)
+            lock = stat.info.arbitrary_metadata.metadata[self.lock_name]
+            self.assertTrue(lock == '')
+        finally:
+            self._remove_share('einstein')
+            self._remove_test_file('einstein', self.file_path)
+
+
+    def test_get_merger(self):
+        try:
+            self._create_test_file('einstein', self.file_path)
+            self._create_share('einstein')
+            self.locks_api.create_working_copy(cs3spr.Reference(path=self.file_path))
+            merger = self.locks_api.get_merger(self.file_path, self.endpoint)
+            self.assertTrue(merger)
+        finally:
+            self._remove_share('einstein')
+            self._remove_test_file('einstein', self.file_path)
+
+    def test_update_lock(self):
+        try:
+            self._create_test_file('einstein', self.file_path)
+            self._create_share('einstein')
+            self.locks_api.create_working_copy(cs3spr.Reference(path=self.file_path))
+            updated = self.locks_api.get_copies_info(self.file_path, self.endpoint)[0]['updated']
+            stat = self.locks_api.stat(cs3spr.Reference(path=self.file_copy_path))
+            self.locks_api.update_lock(stat.info.id.opaque_id, stat.info.id.storage_id)
+            updated_new = self.locks_api.get_copies_info(self.file_path, self.endpoint)[0]['updated']
+            self.assertTrue(updated_new > updated)
+        finally:
+            self._remove_share('einstein')
+            self._remove_test_file('einstein', self.file_path)
+            self._remove_test_file('einstein', self.file_copy_path)
+
+    def test_check_locks(self):
+        try:
+            self._create_test_file('einstein', self.file_path)
+            self._create_share('einstein')
+            self.locks_api.check_locks()
+
+            self.locks_api.create_working_copy(cs3spr.Reference(path=self.file_path))
+            copies = self.locks_api.get_copies_info(self.file_path, self.endpoint)
+            self.assertTrue(len(copies) == 1)
+
+            self.locks_api.check_locks()
+            copies = self.locks_api.get_copies_info(self.file_path, self.endpoint)
+            self.assertTrue(len(copies) == 1)
+
+            time.sleep(60)
+            self.locks_api.check_locks()
+            copies = self.locks_api.get_copies_info(self.file_path, self.endpoint)
+            self.assertTrue(len(copies) == 0)
+        finally:
+            self._remove_share('einstein')
+            self._remove_test_file('einstein', self.file_path)
+            self._remove_test_file('einstein', self.file_copy_path)
+
+    def test_on_open_hook_no_copies(self):
+        try:
+            self._create_test_file('einstein', self.file_path)
+            self.locks_api.on_open_hook(self.file_path, self.endpoint)
+            copy_stat = self.locks_api.stat(cs3spr.Reference(path=self.file_copy_path_uni))
+            self.assertTrue(copy_stat.status.code == cs3code.CODE_NOT_FOUND)
+        finally:
+            self._remove_test_file('einstein', self.file_path)
+
+    def test_on_open_hook_when_copy(self):
+        try:
+            self._create_test_file('einstein', self.file_path)
+            self._create_share('einstein')
+            ref = cs3spr.Reference(path=self.file_path)
+            self.locks_api.create_working_copy(ref)
+            updated = self.locks_api.get_copies_info(self.file_path, self.endpoint)[0]['updated']
+            self.locks_api.on_open_hook(self.file_path, self.endpoint)
+            updated_new = self.locks_api.get_copies_info(self.file_path, self.endpoint)[0]['updated']
+            self.assertTrue(updated_new > updated)
+        finally:
+            self._remove_share('einstein')
+            self._remove_test_file('einstein', self.file_path)
+            self._remove_test_file('einstein', self.locks_file_path)
+            self._remove_test_file('einstein', self.file_copy_path)
+
+    def test_on_close_hook_when_closing_copy(self):
+        try:
+            self._create_test_file('einstein', self.file_path)
+            ref = cs3spr.Reference(path=self.file_path)
+            self.locks_api.create_working_copy(ref)
+            uni_ref = self.locks_api.get_unified_file_ref(self.file_path, self.endpoint)
+            stat = self.locks_api.stat(uni_ref)
+            lock = stat.info.arbitrary_metadata.metadata[self.lock_name]
+            self.assertTrue(lock)
+            self.locks_api.on_close_hook(self.file_copy_path, self.endpoint)
+            stat = self.locks_api.stat(uni_ref)
+            lock = stat.info.arbitrary_metadata.metadata[self.lock_name]
+            self.assertTrue(lock == '')
+        finally:
+            self._remove_test_file('einstein', self.file_path)
+            self._remove_test_file('einstein', self.locks_file_path)
+            self._remove_test_file('einstein', self.file_copy_path)
+
+    def test_flow(self):
+        try:
+            self._create_test_file('einstein', self.file_path)
+            self._create_test_file('einstein', self.file_path2)
+            self._create_share('einstein')
+
+            locks_ref = cs3spr.Reference(path=self.locks_file_path)
+            locks_stat = self.locks_api.stat(locks_ref)
+            self.assertTrue(locks_stat.status.code == cs3code.CODE_NOT_FOUND)
+            ref = cs3spr.Reference(path=self.file_path)
+            copy_ref = cs3spr.Reference(path=self.locks_api._get_copy_path(ref))
+            stat = self.locks_api.stat(copy_ref)
+            self.assertTrue(stat.status.code == cs3code.CODE_NOT_FOUND)
+
+            self.locks_api.on_open_hook(self.file_path, self.endpoint)
+            locks_content = self.locks_api.get_locks_file_content()
+            self.assertTrue(self.file_path_uni in locks_content)
+            stat = self.locks_api.stat(copy_ref)
+            self.assertTrue(stat.status.code == cs3code.CODE_OK)
+            merger = self.locks_api.get_merger(self.file_path, self.endpoint)
+
+            self.locks_api_ext.on_open_hook(self.file_path_uni, self.endpoint)
+            locks_content_marie = self.locks_api_ext.get_locks_file_content()
+            self.assertTrue(self.file_path_uni in locks_content_marie)
+            copy_ref_marie = cs3spr.Reference(path=self.locks_api_ext._get_copy_path(ref))
+            stat_marie = self.locks_api_ext.stat(copy_ref_marie)
+            self.assertTrue(stat_marie.status.code == cs3code.CODE_OK)
+            merger_marie = self.locks_api_ext.get_merger(self.file_path_uni, self.endpoint)
+            self.assertTrue(merger_marie['username'] == 'einstein')
+            copies_marie = self.locks_api_ext.get_copies_info(self.file_path_uni, self.endpoint)
+            self.assertTrue(len(copies_marie) == 2)
+
+        finally:
+            self._remove_share('einstein')
+            self._remove_test_file('einstein', self.file_path)
+            self._remove_test_file('einstein', self.file_copy_path)
+            self._remove_test_file('einstein', self.locks_file_path)
+            self._remove_test_file('marie', self.file_copy_path2)
+            self._remove_test_file('marie', self.locks_file_path)
+
+    def test_is_shared_file(self):
+        try:
+            self._create_test_file('einstein', self.file_path)
+            is_not_shared = self.locks_api.is_shared_file(self.file_path, self.endpoint)
+            self.assertFalse(is_not_shared)
+            self._create_share('einstein')
+            is_shared = self.locks_api.is_shared_file(self.file_path, self.endpoint)
+            self.assertTrue(is_shared)
+        finally:
+            self._remove_share('einstein')
+            self._remove_test_file('einstein', self.file_path)
+
+    def _create_share(self, creator):
+        if creator == self.first_client_id:
+            self.share_id = self.share_api.create(self.endpoint,
+                                                  self.file_path,
+                                                  self.user_opaque_id_1,
+                                                  self.user_idp_1,
+                                                  self.editor_role)['opaque_id']
+        if creator == self.second_client_id:
+            self.share_id = self.share_api_ext.create(self.endpoint,
+                                                      self.file_path2,
+                                                      self.user_opaque_id_2,
+                                                      self.user_idp_2,
+                                                      self.editor_role)['opaque_id']
+
+    def _create_test_file(self, creator, file_path):
+        if creator == self.first_client_id:
+            self.storage.write_file(file_path,
+                                    self.content,
+                                    self.endpoint)
+        if creator == self.second_client_id:
+            self.storage_ext.write_file(file_path,
+                                        self.content,
+                                        self.endpoint)
+
+    def _remove_share(self, owner):
+        if owner == self.first_client_id:
+            self.share_api.remove(self.share_id)
+        if owner == self.second_client_id:
+            self.share_api_ext.remove(self.share_id)
+
+    def _remove_test_file(self, owner, file_path):
+        if owner == self.first_client_id:
+            self.storage.remove(file_path, self.endpoint)
+        if owner == self.second_client_id:
+            self.storage_ext.remove(file_path, self.endpoint)


### PR DESCRIPTION
The idea is based on files metadata. The proposed flow is as follows:
- user creates a share with an original file
- the original file will contain in it's metadata information about locks i.e. who has a copy and if it is used or not
- when opening a file, check if it is a copy or original
- if you open a copy, the correspondent lock present in the original file's metadata will be updated
- if you open the original file, a copy and a lock will be created
- when closing a file, the endpoint deleting a lock should be invoked
- the contributor who has the merging rights would be the one who has the oldest and valid lock

Probably there are corrections to be done to cover some edge cases, but this is the idea in the nutshell. Please take a look and leave comments.