### PR TITLE
Disabled unprivileged file saving

### DIFF
--- a/cs3api4lab/api/share_api_facade.py
+++ b/cs3api4lab/api/share_api_facade.py
@@ -143,12 +143,14 @@ class ShareAPIFacade:
                                'list_container') and share.permissions.permissions.list_container is False:
                         continue
                     model = self._map_share_to_dir_model(share, stat)
+                model['writable'] = True if ShareUtils.map_permissions_to_role(share.permissions.permissions) == 'editor' else False
             except:
                 model = {'name': share.resource_id.opaque_id.rsplit('/', 1)[-1],
                          'path': share.resource_id.opaque_id,
                          'last_modified': '',
                          'created': '',
-                         'content': None, 'format': None,
+                         'content': None,
+                         'format': None,
                          'writable': False,
                          'size': 13,
                          'type':

--- a/cs3api4lab/api/share_utils.py
+++ b/cs3api4lab/api/share_utils.py
@@ -74,7 +74,6 @@ class ShareUtils:
             return None
         if permissions.get_path is True and \
                 permissions.initiate_file_download is True and \
-                permissions.list_grants is True and \
                 permissions.list_container is True and \
                 permissions.stat is True and \
                 permissions.create_container is True and \


### PR DESCRIPTION
This PR is to disable editing a shared file without editor's permissions. Currently the flag 'writable', which is present in file notebook model is effectively ignored. 