### PR TITLE
Enabled hidden files

### DIFF
--- a/cs3api4lab/api/cs3apismanager.py
+++ b/cs3api4lab/api/cs3apismanager.py
@@ -394,29 +394,33 @@ class CS3APIsManager(ContentsManager):
             model['format'] = 'json'
 
             for cs3_model in cs3_container:
-                # ToDo: get data from cs3_model
-                if cs3_model.type == self.TYPE_DIRECTORY:
-                    sub_model = self._convert_container_to_base_model(cs3_model.path, cs3_container)
-                    sub_model['size'] = None
-                    sub_model['type'] = 'directory'
-                    contents.append(sub_model)
+                if not self.is_hidden_file(cs3_model):
+                    # ToDo: get data from cs3_model
+                    if cs3_model.type == self.TYPE_DIRECTORY:
+                        sub_model = self._convert_container_to_base_model(cs3_model.path, cs3_container)
+                        sub_model['size'] = None
+                        sub_model['type'] = 'directory'
+                        contents.append(sub_model)
 
-                elif cs3_model.type == self.TYPE_FILE:
+                    elif cs3_model.type == self.TYPE_FILE:
 
-                    if type == 'notebook' or (type is None and path.endswith('.ipynb')):
-                        contents.append(
-                            self._convert_container_to_notebook_model(cs3_model, cs3_container)
-                        )
+                        if type == 'notebook' or (type is None and path.endswith('.ipynb')):
+                            contents.append(
+                                self._convert_container_to_notebook_model(cs3_model, cs3_container)
+                            )
+                        else:
+                            contents.append(
+                                self._convert_container_to_file_model(cs3_model, cs3_container)
+                            )
                     else:
-                        contents.append(
-                            self._convert_container_to_file_model(cs3_model, cs3_container)
-                        )
-                else:
 
-                    self.log.error(u'Unexpected type: %s %s', cs3_model.path, cs3_model.type)
-                    raise web.HTTPError(500, u'Unexpected type: %s %s' % (cs3_model.path, cs3_model.type))
+                        self.log.error(u'Unexpected type: %s %s', cs3_model.path, cs3_model.type)
+                        raise web.HTTPError(500, u'Unexpected type: %s %s' % (cs3_model.path, cs3_model.type))
 
         return model
+
+    def is_hidden_file(self, cs3_model):
+        return cs3_model.id.opaque_id.split('%2F')[-1].startswith('.')
 
     def _convert_container_to_file_model(self, cs3_model, cs3_container):
 

--- a/cs3api4lab/tests/test_cs3apismanager.py
+++ b/cs3api4lab/tests/test_cs3apismanager.py
@@ -39,6 +39,21 @@ class TestCS3APIsManager(TestCase, LoggingConfigurable):
 
         self.storage.remove(file_id, self.endpoint)
 
+    def test_get_hidden_file(self):
+        file_id = "/test_get_text_file.txt"
+        hidden_file_id = "/.test_get_text_file.txt"
+        message = "Lorem ipsum dolor sit amet..."
+        self.storage.write_file(file_id, message, self.endpoint)
+        self.storage.write_file(hidden_file_id, message, self.endpoint)
+
+        model = self.contents_manager.get(file_id, True, None)
+        self.assertEqual(model["name"], "test_get_text_file.txt")
+        self.assertEqual(model["path"], file_id)
+        self.assertTrue(self.contents_manager.file_exists(hidden_file_id))
+
+        self.storage.remove(file_id, self.endpoint)
+        self.storage.remove(hidden_file_id, self.endpoint)
+
     def test_get_text_file_with_share_path(self):
         file_id = "/test_get_text_file.txt"
         share_file_id = "/reva/einstein/test_get_text_file.txt"


### PR DESCRIPTION
This PR is to fix hidden files. Hiding files starting with a dot was implemented sometime in the begining of development but didn't work. This will be also useful in locks.