### PR TITLE
Refactored get grantees for file endpoint

### DIFF
--- a/cs3api4lab/api/cs3_file_api.py
+++ b/cs3api4lab/api/cs3_file_api.py
@@ -145,7 +145,10 @@ class Cs3FileApi:
         time_start = time.time()
         reference = file_utils.get_reference(file_path, endpoint)
 
-        content_len = len(content.decode('utf-8'))
+        if isinstance(content, str):
+            content_len = len(content)
+        else:
+            content_len = len(content.decode('utf-8'))
         # providing '0' as size leads to unexpected additional file creation
         content_size = str(content_len) if content_len > 0 else str(1)
 

--- a/cs3api4lab/api/share_utils.py
+++ b/cs3api4lab/api/share_utils.py
@@ -3,6 +3,8 @@ import cs3.storage.provider.v1beta1.resources_pb2 as storage_resources
 from cs3api4lab.common.strings import *
 from cs3api4lab.exception.exceptions import *
 
+import urllib.parse
+
 
 class ShareUtils:
 
@@ -84,3 +86,19 @@ class ShareUtils:
             return Role.EDITOR
         else:
             return Role.VIEWER
+
+    @staticmethod
+    def decode_file_path(file_path):
+        """
+        Decodes file path, as the CS3 API contains URL encoded paths
+        """
+        return urllib.parse.unquote(file_path)
+
+    @staticmethod
+    def purify_file_path(file_path, user):
+        """
+        Transforms 'fileid-user%2F' or '/home/' into '/reva/user'
+        """
+        if file_path.startswith('/home'):
+            return ShareUtils.decode_file_path(file_path.replace('/home', '/reva/' + user))
+        return ShareUtils.decode_file_path(file_path.replace('fileid-' + user, '/reva/' + user))

--- a/cs3api4lab/tests/test_uni_share_api.py
+++ b/cs3api4lab/tests/test_uni_share_api.py
@@ -309,6 +309,33 @@ class TestCs3UniShareApi(TestCase, LoggingConfigurable):
             if self.file_name:
                 self.remove_test_file('einstein', self.file_name)
 
+    def test_get_grantees_for_file(self):
+        try:
+            self.file_name = self.file_path + self._get_file_suffix()
+            created_share = self.create_share('einstein', self.richard_id, self.richard_idp, self.file_name)
+            self.ocm_file_name = self.file_path + self._get_file_suffix()
+            created_ocm_share = self.create_ocm_share('einstein', self.marie_id, self.marie_idp, self.ocm_file_name)
+            self.share_id = created_share['opaque_id']
+            self.ocm_share_id = created_ocm_share['id']
+
+            grantees = self.uni_api.list_grantees_for_file(self.file_name)
+            if not grantees['shares']:
+                raise Exception("Grantees not found")
+
+            grantees = self.uni_api.list_grantees_for_file(self.ocm_file_name)
+            if not grantees['shares']:
+                raise Exception("Grantees not found")
+
+        finally:
+            if self.share_id:
+                self.remove_test_share('einstein', self.share_id)
+            if self.ocm_share_id:
+                self.remove_test_ocm_share('einstein', self.ocm_share_id)
+            if self.ocm_file_name:
+                self.remove_test_file('einstein', self.ocm_file_name)
+            if self.file_name:
+                self.remove_test_file('einstein', self.file_name)
+
     def create_ocm_share(self, user, ocm_receiver_id, ocm_receiver_idp, file_path):
         self.create_test_file(user, file_path)
         if user == 'einstein':

--- a/src/infobox.tsx
+++ b/src/infobox.tsx
@@ -204,7 +204,7 @@ const Shares = (props: SharesProps): JSX.Element => {
 
     useEffect(() => {
         const getGrantees = async (): Promise<any> => {
-            const resource = '/home/' + props.content.path.replace('cs3drive:', '');
+            const resource = '/' + props.content.path.replace('cs3driveShareByMe:', '');
 
             requestAPI<any>('/api/cs3/shares/file?file_path=' + resource, {
                 method: 'GET'


### PR DESCRIPTION
Refactored and simplified get grantees for file endpoint:
- fixed a bug on frontend 
- added ocm grantees to the response
- simplified logic