### PR TITLE
Make OCM optional

### DIFF
--- a/cs3api4lab/config/config_manager.py
+++ b/cs3api4lab/config/config_manager.py
@@ -13,6 +13,7 @@ class Config(LoggingConfigurable):
         "endpoint": "/",
         "home_dir": "/home",
         "root_dir_list": "/home,/reva", # List of root dirs. Example: Exaple config "/home,/reva" for storage-references: https://developer.sciencemesh.io/docs/iop/deployment/kubernetes/providers/
+        "enable_ocm": True,
         "chunk_size": "4194304",
         "secure_channel": False,
         "client_cert": "",


### PR DESCRIPTION
Closes #83 

The objective here is to prevent calling the OCM api if not enabled, while at the same time giving an exception in case some request ends up requiring that functionality.

Please review if it makes sense (didn't do extensive testing).