### PR TITLE
Set up CI that builds Docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,14 @@
+name: Build Docker image
+
+on: push
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build  .


### PR DESCRIPTION
Contributes to #29

This job just builds the Docker image after every git push. It does not push the resulting image anywhere, so it can be considered just as a validation of changes made to the repo.

This jobs is failing now. Thanks to this, we can see that there is a problem in the current state of the repo.

I think this PR should be merged even when the job is failing, as the cause is elsewhere. Thanks to this PR, we will see if the problem is fixed or not.