### PR TITLE
optimize user search

### DIFF
--- a/cs3api4lab/api/cs3_user_api.py
+++ b/cs3api4lab/api/cs3_user_api.py
@@ -45,7 +45,10 @@ class Cs3UserApi:
             return {}
 
     def find_users_by_query(self, query):
-        response = self.api.FindUsers(user_api.FindUsersRequest(filter=query),
+        if len(query) < 3:
+            return []
+
+        response = self.api.FindUsers(user_api.FindUsersRequest(filter=query, skip_fetching_user_groups=True),
                                       metadata=[('x-access-token', self.auth.authenticate())])
         ocm_users = []
         if self.config['enable_ocm']:


### PR DESCRIPTION
limit characters to min 3, when searching for a user, add parameter to skip searching user groups

This is a temporary fix, we are still working on doing the character limititation with validators. It's taking more time, because tornado doesn't implement them by default.