### PR TITLE
Locks metadata fix

### DIFF
--- a/cs3api4lab/api/lock_manager.py
+++ b/cs3api4lab/api/lock_manager.py
@@ -2,6 +2,7 @@ import json
 import time
 import datetime
 import grpc
+import urllib.parse
 
 import cs3.gateway.v1beta1.gateway_api_pb2 as cs3gw
 import cs3.gateway.v1beta1.gateway_api_pb2_grpc as cs3gw_grpc
@@ -33,13 +34,13 @@ class LockManager:
 
     def generate_lock_entry(self):
         user = self._get_current_user()
-        return {self.get_my_lock_name(): json.dumps({
+        return {self.get_my_lock_name(): urllib.parse.quote(json.dumps({
             "username": user.username,
             "idp": user.id.idp,
             "opaque_id": user.id.opaque_id,
             "updated": time.time(),
             "created": time.time()
-        })}
+        }))}
 
     def get_my_lock_name(self):
         user = self._get_current_user()
@@ -109,4 +110,4 @@ class LockManager:
         metadata = self.storage_logic.get_metadata(file_path, endpoint)
         if not metadata:
             return
-        return json.loads(list(metadata.values())[0])
+        return json.loads(urllib.parse.unquote(list(metadata.values())[0]))

--- a/cs3api4lab/tests/test_locks.py
+++ b/cs3api4lab/tests/test_locks.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 from time import sleep
 from cs3api4lab.tests.share_test_base import ShareTestBase
 from traitlets.config import LoggingConfigurable
-
+import urllib.parse
 
 class TestLocks(ShareTestBase, TestCase, LoggingConfigurable):
     einstein_id = '4c510ada-c86b-4815-8820-42cdf82c3d51'
@@ -35,7 +35,7 @@ class TestLocks(ShareTestBase, TestCase, LoggingConfigurable):
             self.assertTrue(file_info.arbitrary_metadata.metadata)
             self.assertIn("lock_einstein_cernbox.cern.ch_4c510ada-c86b-4815-8820-42cdf82c3d51", file_info.arbitrary_metadata.metadata)
             
-            lock = json.loads(file_info.arbitrary_metadata.metadata["lock_einstein_cernbox.cern.ch_4c510ada-c86b-4815-8820-42cdf82c3d51"])
+            lock = json.loads(urllib.parse.unquote(file_info.arbitrary_metadata.metadata["lock_einstein_cernbox.cern.ch_4c510ada-c86b-4815-8820-42cdf82c3d51"]))
             self.assertEquals(lock['username'], 'einstein')
             self.assertEquals(lock['idp'], 'cernbox.cern.ch')
             self.assertEquals(lock['opaque_id'], '4c510ada-c86b-4815-8820-42cdf82c3d51')
@@ -61,7 +61,7 @@ class TestLocks(ShareTestBase, TestCase, LoggingConfigurable):
             self.assertTrue(file_info.arbitrary_metadata.metadata)
             self.assertIn("lock_einstein_cernbox.cern.ch_4c510ada-c86b-4815-8820-42cdf82c3d51", file_info.arbitrary_metadata.metadata)
             
-            lock = json.loads(file_info.arbitrary_metadata.metadata["lock_einstein_cernbox.cern.ch_4c510ada-c86b-4815-8820-42cdf82c3d51"])
+            lock = json.loads(urllib.parse.unquote(file_info.arbitrary_metadata.metadata["lock_einstein_cernbox.cern.ch_4c510ada-c86b-4815-8820-42cdf82c3d51"]))
             self.assertEquals(lock['username'], 'einstein')
             self.assertEquals(lock['idp'], 'cernbox.cern.ch')
             self.assertEquals(lock['opaque_id'], '4c510ada-c86b-4815-8820-42cdf82c3d51')


### PR DESCRIPTION
This is a fix to a problem discovered during CERNBox testing. Please merge it before #118 